### PR TITLE
c12e-ci: fix of JSON reporting

### DIFF
--- a/bin/c12e-ci
+++ b/bin/c12e-ci
@@ -349,7 +349,7 @@ write_report()
     if on_ci_server
     then
         mkdir -p "$target_dir"
-        echo "[" >> "$target_dir/buildReport.json"
+        echo "[" > "$target_dir/buildReport.json"
         echo "$published" | \
             while read -r pair
             do
@@ -365,7 +365,7 @@ write_report()
                 if [ "$printed_first" = "true" ]
                 then echo "," >> "$target_dir/buildReport.json"
                 fi
-                cat << EOF > "$target_dir/buildReport.json"
+                cat << EOF >> "$target_dir/buildReport.json"
 {
    "name": "$repo",
    "docker_file": "$dockerfile",


### PR DESCRIPTION
There was a > (overwrite) where there should have been an >> (append) in
the shell script.