### PR TITLE
CCF-12016 install python3 and ruamel.yaml on gocd-agents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@
 FROM docker:1.11.2-dind
 
 # version is a mess as the zip doesn't include the build number..
-RUN apk --no-cache add python py-pip bash unzip openjdk8-jre git curl openssh jq ca-certificates \
+RUN apk --no-cache add python python3 py-pip bash unzip openjdk8-jre git curl openssh jq ca-certificates \
 && CONSUL_TEMPLATE_VERSION=0.14.0 \
 && wget https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
+&& pip3 install -U setuptools wheel \
 && unzip consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
 && mv consul-template /usr/local/bin/consul-template \
 && rm consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
@@ -27,6 +28,7 @@ RUN apk --no-cache add python py-pip bash unzip openjdk8-jre git curl openssh jq
 && chmod +x yq \
 && mv yq /usr/local/bin \
 && pip install awscli \
+&& pip3 install ruamel.yaml \
 && wget https://raw.github.com/nvie/gitflow/develop/contrib/gitflow-installer.sh \
 && chmod +x gitflow-installer.sh \
 && ./gitflow-installer.sh

--- a/Dockerfile.c12e-ci.gocd-agent
+++ b/Dockerfile.c12e-ci.gocd-agent
@@ -2,9 +2,10 @@
 FROM docker:1.11.2-dind
 
 # version is a mess as the zip doesn't include the build number..
-RUN apk --no-cache add python py-pip bash unzip openjdk8-jre git curl openssh jq ca-certificates \
+RUN apk --no-cache add python python3 py-pip bash unzip openjdk8-jre git curl openssh jq ca-certificates \
 && CONSUL_TEMPLATE_VERSION=0.14.0 \
 && wget https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
+&& pip3 install -U setuptools wheel \
 && unzip consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
 && mv consul-template /usr/local/bin/consul-template \
 && rm consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip \
@@ -27,6 +28,7 @@ RUN apk --no-cache add python py-pip bash unzip openjdk8-jre git curl openssh jq
 && chmod +x yq \
 && mv yq /usr/local/bin \
 && pip install awscli \
+&& pip3 install ruamel.yaml \
 && wget https://raw.github.com/nvie/gitflow/develop/contrib/gitflow-installer.sh \
 && chmod +x gitflow-installer.sh \
 && ./gitflow-installer.sh


### PR DESCRIPTION
ruamel.yaml over pyyaml keeps the original yaml order and comments so only versions are updated in our values.yaml.  Had to install some prereqs for it.